### PR TITLE
feat: Add link list format

### DIFF
--- a/src/copy.ts
+++ b/src/copy.ts
@@ -51,12 +51,18 @@ function applyTextTransformToTabs(
     throw new Error(`no transform for ${representation} in format "${formatName}"`)
   }
 
-  if (!tabs.length) {
+  // Filter out unwanted URLs
+  const filteredTabs = tabs.filter(tab => 
+    !(tab.url?.startsWith('https://calendar.google.com') || 
+      tab.url === 'https://drive.google.com/drive/home')
+  )
+
+  if (!filteredTabs.length) {
     console.warn(`no tabs to copy as "${formatName}" ${representation}. check filter options.`)
   } else {
     log(
-      `transforming ${tabs.length} ${
-        tabs.length === 1 ? 'tab' : 'tabs'
+      `transforming ${filteredTabs.length} ${
+        filteredTabs.length === 1 ? 'tab' : 'tabs'
       } to "${formatName}" ${representation}`,
     )
   }
@@ -64,15 +70,15 @@ function applyTextTransformToTabs(
   return `${
     transform.start?.({
       formatName,
-      tabCount: tabs.length,
+      tabCount: filteredTabs.length,
       scopeType: 'tab',
     }) ?? ''
-  }${tabs
+  }${filteredTabs
     .map((tab, i) => transform.tab?.({ tab, globalSeq: i + 1 }) ?? '')
     .join(transform.tabDelimiter ?? '')}${
     transform.end?.({
       formatName,
-      tabCount: tabs.length,
+      tabCount: filteredTabs.length,
     }) ?? ''
   }`
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -57,6 +57,28 @@ const builtinFormats = [
     }),
     // todo: potential opt: plaintext fallback (title or url)
   },
+    {
+    id: 'linkList',
+    label: () => 'Link List',
+    description: () => sentenceCase(intl.linkDescription()),
+    transforms: () => ({
+      text: urlTextTransform,
+      html: {
+        windowStart: ({ seq }) => `${getNumberedWindowText(seq)}<br>\n<br>\n`,
+
+        start: () => '<ul>',
+
+        tab: ({ tab }) => `<li>${getAnchorTagHtml(tab)}</li>`,
+
+        end: () => '</ul>',
+        
+        tabDelimiter: '\n',
+
+        windowDelimiter: '\n\n',
+      },
+    }),
+    // todo: potential opt: plaintext fallback (title or url)
+  },
   {
     id: 'url',
     label: () => intl.url(),

--- a/src/format.ts
+++ b/src/format.ts
@@ -178,9 +178,10 @@ const builtinFormats = [
         tab: ({ tab: { title, url } }) =>
           `- [${
             // wrap
-            (title || url!) // wrap
+            (`${title || url!} | ${getDomain(url)}`) // wrap
               .replace(/\[/g, '\\[')
               .replace(/\]/g, '\\]')
+              .replace(/\./g, '·')
           }](${
             // wrap
             url! // wrap
@@ -530,10 +531,39 @@ function getTitleUrlText(
   return `${title || '(untitled)'}${separator}${url}`
 }
 
+  /**
+   * Returns an HTML string for an anchor tag wrapping the given tab's title and
+   * URL. If the tab has no title, the URL is used as the link text.
+   *
+   * @param tab The tab for which to generate the anchor tag.
+   * @returns An HTML string for an anchor tag, or an empty string if the tab has
+   * no URL.
+   */
 function getAnchorTagHtml(tab: chrome.tabs.Tab) {
   return tab.url // wrap
-    ? `<a href="${tab.url}">${encodeHtml(tab.title || tab.url)}</a>`
+    ? `<a href="${tab.url}">${encodeHtml(`${tab.title || tab.url} | ${getDomain(tab.url)}`)}</a>`
     : ''
+}
+
+  /**
+   * Returns the domain of a URL, stripping any leading "www." from the hostname.
+   * Returns an empty string if the input is not a valid URL.
+   */
+function getDomain(urlString: string | undefined) {
+  if (!urlString) {
+    return '';
+  }
+  try {
+    const url = new URL(urlString);
+    let hostname = url.hostname;
+    if (hostname.startsWith('www.')) {
+      hostname = hostname.slice(4);
+    }
+    return hostname;
+  } catch (error) {
+    console.error('Failed to parse URL:', error);
+    return '';
+  }
 }
 
 function getNumberedWindowText(seq: number) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -59,7 +59,7 @@ const builtinFormats = [
   },
     {
     id: 'linkList',
-    label: () => 'Link List',
+    label: () => 'Link list',
     description: () => sentenceCase(intl.linkDescription()),
     transforms: () => ({
       text: urlTextTransform,
@@ -160,6 +160,35 @@ const builtinFormats = [
           })`,
 
         tabDelimiter: '\n\n',
+
+        windowDelimiter: '\n\n',
+      },
+    }),
+    // todo: potential opt: markdown flavor
+    // todo: potential opt: window header level (h1, h2, etc)
+  },
+  {
+    id: 'markdownList',
+    label: () => 'Markdown list',
+    transforms: () => ({
+      // todo: make special char escaping more robust across popular markdown renderers (github, etc); https://stackoverflow.com/questions/13824669/how-do-you-write-a-link-containing-a-closing-bracket-in-markdown-syntax
+      text: {
+        windowStart: ({ seq }) => `## ${getNumberedWindowText(seq)}\n\n`,
+
+        tab: ({ tab: { title, url } }) =>
+          `- [${
+            // wrap
+            (title || url!) // wrap
+              .replace(/\[/g, '\\[')
+              .replace(/\]/g, '\\]')
+          }](${
+            // wrap
+            url! // wrap
+              .replace(/\(/g, '\\(')
+              .replace(/\)/g, '\\)')
+          })`,
+
+        tabDelimiter: '\n',
 
         windowDelimiter: '\n\n',
       },

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -7,7 +7,7 @@ export const intl = {
 
   copyAs: () => 'copy as',
 
-  copy1xAs: () => 'copy 1x as',
+  copy1xAs: () => 'copy as',
 
   holdWhenCopying: (keyModifier: string) => `hold ${keyModifier} when copying`,
 

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -16,4 +16,5 @@ export function encodeHtml(html: string) {
     .replace(/>/g, '&gt;')
     .replace(/'/g, '&#39;')
     .replace(/"/g, '&#34;')
+    .replace(/\./g, '&middot;') // replaces period with middle dot, to ensure that the title is not misinterpreted as a URL
 }


### PR DESCRIPTION
This adds a link list format, in both HTML and Markdown, which is useful for copying into tools that work well with a list format (e.g. https://reflect.app/, https://www.sunsama.com/) and also into Trello and GitHub